### PR TITLE
Respect username from params.pp

### DIFF
--- a/manifests/access/file.pp
+++ b/manifests/access/file.pp
@@ -30,7 +30,7 @@ class sendmail::access::file (
     ensure  => file,
     content => $content,
     source  => $source,
-    owner   => 'smmta',
+    owner   => $::sendmail::params::sendmail_user,
     group   => $::sendmail::params::sendmail_group,
     mode    => '0640',
     notify  => Class['::sendmail::makeall'],

--- a/manifests/domaintable/file.pp
+++ b/manifests/domaintable/file.pp
@@ -30,7 +30,7 @@ class sendmail::domaintable::file (
     ensure  => file,
     content => $content,
     source  => $source,
-    owner   => 'smmta',
+    owner   => $::sendmail::params::sendmail_user,
     group   => $::sendmail::params::sendmail_group,
     mode    => '0640',
     notify  => Class['::sendmail::makeall'],

--- a/manifests/genericstable/file.pp
+++ b/manifests/genericstable/file.pp
@@ -30,7 +30,7 @@ class sendmail::genericstable::file (
     ensure  => file,
     content => $content,
     source  => $source,
-    owner   => 'smmta',
+    owner   => $::sendmail::params::sendmail_user,
     group   => $::sendmail::params::sendmail_group,
     mode    => '0640',
     notify  => Class['::sendmail::makeall'],

--- a/manifests/mailertable/file.pp
+++ b/manifests/mailertable/file.pp
@@ -30,7 +30,7 @@ class sendmail::mailertable::file (
     ensure  => file,
     content => $content,
     source  => $source,
-    owner   => 'smmta',
+    owner   => $::sendmail::params::sendmail_user,
     group   => $::sendmail::params::sendmail_group,
     mode    => '0644',
     notify  => Class['::sendmail::makeall'],

--- a/manifests/userdb/file.pp
+++ b/manifests/userdb/file.pp
@@ -30,7 +30,7 @@ class sendmail::userdb::file (
     ensure  => file,
     content => $content,
     source  => $source,
-    owner   => 'smmta',
+    owner   => $::sendmail::params::sendmail_user,
     group   => $::sendmail::params::sendmail_group,
     mode    => '0640',
     notify  => Class['::sendmail::makeall'],

--- a/manifests/virtusertable/file.pp
+++ b/manifests/virtusertable/file.pp
@@ -30,7 +30,7 @@ class sendmail::virtusertable::file (
     ensure  => file,
     content => $content,
     source  => $source,
-    owner   => 'smmta',
+    owner   => $::sendmail::params::sendmail_user,
     group   => $::sendmail::params::sendmail_group,
     mode    => '0640',
     notify  => Class['::sendmail::makeall'],


### PR DESCRIPTION
Using sendmail_user from params.pp instead of hardcoded "smmta"-user. (smmta doesn't exist on CentOS 7-systems)