### PR TITLE
facter code error checking

### DIFF
--- a/lib/facter/sendmail_version.rb
+++ b/lib/facter/sendmail_version.rb
@@ -4,11 +4,15 @@
 #
 Facter.add(:sendmail_version) do
   setcode do
-    command = 'sendmail -d0.4 -ODontProbeInterfaces=true -bv root 2>/dev/null'
-    version = Facter::Core::Execution.execute(command, { :on_fail => nil })
-    if version =~ /^Version ([0-9.]+)$/
-      $1
-    else
+    begin
+      command = 'sendmail -d0.4 -ODontProbeInterfaces=true -bv root 2>/dev/null'
+      version = Facter::Core::Execution.execute(command, { :on_fail => nil })
+      if version =~ /^Version ([0-9.]+)$/
+        $1
+      else
+        nil
+      end
+    rescue Facter::Core::Execution::ExecutionFailure
       nil
     end
   end


### PR DESCRIPTION
Currently the facter code returns an error if it can't properly run sendmail (e.g. systems with postfix installed which has its own sendmail wrapper that doesn't work with the facter code).  This fills up the log files needlessly.  This patch uses rescue to catch this case and silence the error.  Submitted for your consideration.  (I'm not a ruby programmer, so this code may not be of the highest quality, but it works on my test systems...)