### PR TITLE
 Updating metadata name dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,11 +32,11 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.2.0 < 5.0.0"
     },
     {
-      "name": "puppetlabs-concat",
+      "name": "puppetlabs/concat",
       "version_requirement": ">= 1.2.0 < 3.0.0"
     }
   ],


### PR DESCRIPTION
On newer versions of puppet it fails checking for dependencies, changing '-' for '/' solves the issue:

Warning: Missing dependency 'puppetlabs-concat':
  'stm-sendmail' (v0.6.1) requires 'puppetlabs-concat' (>= 1.2.0 < 3.0.0)
Warning: Missing dependency 'puppetlabs-stdlib':
  'stm-sendmail' (v0.6.1) requires 'puppetlabs-stdlib' (>= 4.2.0 < 5.0.0)