### PR TITLE
Solaris support along with Postfix collision prevention

### DIFF
--- a/lib/facter/sendmail_version.rb
+++ b/lib/facter/sendmail_version.rb
@@ -6,12 +6,16 @@ Facter.add(:sendmail_version) do
   setcode do
     begin
       options = { :on_fail => nil, :timeout => 10 }
-      command = 'sendmail -d0.4 -ODontProbeInterfaces=true -bv root 2>/dev/null'
-      version = Facter::Core::Execution.execute(command, options)
-      if version =~ /^Version ([0-9.]+)$/
-        $1
-      else
-        nil
+      postfix = 'man sendmail 2>/dev/null | grep "postfix" | wc -l | awk \'{print $1}\''
+      chkpofx = Facter::Core::Execution.execute(postfix, options)
+      if execpfx == '0'
+        command = 'sendmail -d0.4 -ODontProbeInterfaces=true -bv root 2>/dev/null'
+        version = Facter::Core::Execution.execute(command, options)
+        if version =~ /^Version ([0-9.]+).*$/
+          $1
+        else
+          nil
+        end
       end
     rescue Facter::Core::Execution::ExecutionFailure
       nil

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,6 +107,27 @@ class sendmail::params {
       $submit_mc_file    = "${mail_settings_dir}/${::hostname}.submit.mc"
     }
 
+    'Solaris':{
+      $package_manage   = false
+      $service_hasstatus = true
+
+      $sendmail_user    = 'root'
+      $sendmail_group   = 'mail'
+      $alias_file_group = 'root'
+
+      $sendmail_mc_ostype = 'solaris8'
+      $submit_mc_ostype   = undef
+      $sendmail_mc_domain = 'solaris-generic'
+      $submit_mc_domain   = undef
+
+      $configure_command = "cd ${mail_settings_dir}/cf/cf && \n
+                            /usr/ccs/bin/make all && \n
+                            cp sendmail.cf ${mail_settings_dir}/sendmail.cf && \n
+                            cp submit.cf ${mail_settings_dir}/submit.cf "
+      $sendmail_mc_file  = "${mail_settings_dir}/cf/cf/sendmail.mc"
+      $submit_mc_file    = "${mail_settings_dir}/cf/cf/submit.mc"
+    }
+
     default: {
       fail("Unsupported osfamily ${::osfamily}")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -46,6 +46,13 @@
         "10",
         "11"
       ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Note that in many environments postfix might exist intentionally on hosts that share the same puppet code environment. This sendmail module causes errors in the maillog from postfix every time facter calls the included lib for sendmail_version. This should be resolved with these changes.

Also, change made here should offer basic Solaris compatibility, and has been running production for the company I work for going on 6+ months now.