### PR TITLE
Add sendmail::mc::virtuser_domain

### DIFF
--- a/manifests/mc.pp
+++ b/manifests/mc.pp
@@ -126,6 +126,7 @@ class sendmail::mc (
   # 33    # queue group header
   # 34    QUEUE_GROUP
   # 35    # macro header
+  # 37    VIRTUSER_DOMAIN
   # 38    MODIFY_MAILER_FLAGS
   # 40    DAEMON_OPTIONS
   # 45    TRUST_AUTH_MECH

--- a/manifests/mc/virtuser_domain.pp
+++ b/manifests/mc/virtuser_domain.pp
@@ -1,0 +1,31 @@
+# = Define: sendmail::mc::virtuser_domain
+#
+# Add the VIRTUSER_DOMAIN macro to the sendmail.mc file.
+#
+# == Parameters:
+#
+# [*domain*]
+#   The name of the domain to add to the VirtUser class.
+#   Default value is the resource title.
+#
+# == Requires:
+#
+# Nothing.
+#
+# == Sample Usage:
+#
+#   sendmail::mc::virtuser_domain { 'example.net': }
+#
+#
+define sendmail::mc::virtuser_domain (
+  Stdlib::Fqdn $domain = $title,
+) {
+  concat::fragment { "sendmail_mc-virtuser_domain-${domain}":
+    target  => 'sendmail.mc',
+    order   => '37',
+    content => "VIRTUSER_DOMAIN(`${domain}')dnl\n",
+  }
+
+  # Also add the section header
+  include sendmail::mc::macro_section
+}

--- a/spec/defines/mc/virtuser_domain_spec.rb
+++ b/spec/defines/mc/virtuser_domain_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'sendmail::mc::virtuser_domain' do
+  context 'with domain example.net' do
+    let(:title) { 'example.net' }
+
+    it {
+      should contain_concat__fragment('sendmail_mc-virtuser_domain-example.net') \
+              .with_content(/^VIRTUSER_DOMAIN\(`example.net'\)dnl$/) \
+              .with_order('37')
+      should contain_class('sendmail::mc::macro_section')
+    }
+  end
+end


### PR DESCRIPTION
Added defined type to allow setting VIRTUSER_DOMAIN macro to configure virtual domains.