### PR TITLE
Fix for authinfo entry not created, because of clashing of single quotes

### DIFF
--- a/manifests/authinfo/entry.pp
+++ b/manifests/authinfo/entry.pp
@@ -95,7 +95,7 @@ define sendmail::authinfo::entry (
   $changes = $ensure ? {
     'present' => [
       "set key[. = '${key}'] '${key}'",
-      "set key[. = '${key}']/value '${value}'",
+      "set key[. = '${key}']/value \"${value}\"",
     ],
     'absent'  => "rm key[ . = '${key}']",
   }


### PR DESCRIPTION
There is a error with the quoted_values

  # Add quotes to each array element
  $quoted_values = $real_values.map |$item| { "`${item}'" }

It adds a '  quote, which makes the set key not working anymore, because it also use the same quote

      "set key[. = '${key}']/value '${value}'",

So changed it to
      "set key[. = '${key}']/value \"${value}\"",

Which works